### PR TITLE
Use kafka 5.4.1 + change log level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,13 +21,32 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.canelmas.kafka</groupId>
-    <artifactId>connect-s3-fieldandtime-partitioner</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <artifactId>connect-fieldandtime-partitioner</artifactId>
+    <version>stuart-1.0.0</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <packaging>jar</packaging>
 
     <properties>
-        <confluent.version>5.3.0-SNAPSHOT</confluent.version>
+        <confluent.version>5.4.1</confluent.version>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+    </repositories>
 
     <dependencies>
         <dependency>
@@ -43,7 +62,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
-            <version>2.3.0</version>
+            <version>${confluent.version}-ccs</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/canelmas/kafka/connect/FieldAndTimeBasedPartitioner.java
+++ b/src/main/java/com/canelmas/kafka/connect/FieldAndTimeBasedPartitioner.java
@@ -138,7 +138,7 @@ public final class FieldAndTimeBasedPartitioner<T> extends TimeBasedPartitioner<
                 final Object field = DataUtils.getNestedFieldValue(value, fieldName);
                 final Schema fieldSchema = DataUtils.getNestedField(record.valueSchema(), fieldName).schema();
 
-                FieldAndTimeBasedPartitioner.log.error("Unsupported type '{}' for partition field.", fieldSchema.type().getName());
+                FieldAndTimeBasedPartitioner.log.warn("Unsupported type '{}' for partition field.", fieldSchema.type().getName());
 
                 return (String) field;
 

--- a/src/main/java/com/canelmas/kafka/connect/FieldAndTimeBasedPartitioner.java
+++ b/src/main/java/com/canelmas/kafka/connect/FieldAndTimeBasedPartitioner.java
@@ -138,6 +138,8 @@ public final class FieldAndTimeBasedPartitioner<T> extends TimeBasedPartitioner<
                 final Object field = DataUtils.getNestedFieldValue(value, fieldName);
                 final Schema fieldSchema = DataUtils.getNestedField(record.valueSchema(), fieldName).schema();
 
+                // changed this log to warn level because otherwise it gives an error with type string when reading from
+                // Avro. The error is not risen when reading strings from json
                 FieldAndTimeBasedPartitioner.log.warn("Unsupported type '{}' for partition field.", fieldSchema.type().getName());
 
                 return (String) field;


### PR DESCRIPTION
This PR won't be merged. We will keep the branch `stuart-1.0.0` as the standard one for stuart.

Changes:
1. change the kafka version in the repo to use the one of stuart cluster
2. add the confluent repository to retrieve the dependencies
3. change mvn compiler version to make it work with the newer versions of java
4. change the wrong log form error to warn.

You may ask "why such a silly solution as removing the error log"? 
Well, it seems that log is out of place, if you look at the last version of master that log is not even present anymore. However I couldn't use the last master version of the project because it doesn't have a release and it doesn't seem ready to use (I've tested it and got lot of different errors).
So I think this can be a workaround while waiting for a new stable release of the original repo.